### PR TITLE
Use correct buildpack position during post

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cloudfoundry/go-cf-api
 go 1.17
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/friendsofgo/errors v0.9.2
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/go-playground/validator/v10 v10.6.1
@@ -41,7 +42,6 @@ require (
 	github.com/Antonboom/errname v0.1.5 // indirect
 	github.com/Antonboom/nilnil v0.1.0 // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect

--- a/internal/api/v3/buildpacks/controller.go
+++ b/internal/api/v3/buildpacks/controller.go
@@ -14,6 +14,7 @@ const GUIDParam = "guid"
 var (
 	buildpackQuerier                           = func(qm ...qm.QueryMod) models.BuildpackFinisher { return models.Buildpacks(qm...) }
 	buildpackInserter models.BuildpackInserter = models.Buildpacks()
+	buildpackUpdater  models.BuildpackUpdater  = models.Buildpacks()
 )
 
 type Controller struct {

--- a/internal/api/v3/buildpacks/post.go
+++ b/internal/api/v3/buildpacks/post.go
@@ -19,8 +19,8 @@ import (
 )
 
 type PostRequest struct {
-	Name     string  `json:"name" validate:"required len=250"`
-	Stack    *string `json:"stack" validate:"len=250"`
+	Name     string  `json:"name" validate:"required,min=1,max=250"`
+	Stack    *string `json:"stack" validate:"omitempty,max=250"`
 	Position int     `json:"position" validate:"gte=1"`
 	Enabled  bool    `json:"enabled"`
 	Locked   bool    `json:"locked"`
@@ -57,7 +57,7 @@ func (cont *Controller) Post(echoCtx echo.Context) error {
 		return v3.UnprocessableEntity("Could not parse JSON provided in the body", err)
 	}
 
-	err := validator.New().Struct(buildpackInserter)
+	err := validator.New().Struct(requestBody)
 	if err != nil {
 		return v3.BadQueryParameter(err)
 	}

--- a/internal/api/v3/buildpacks/post_test.go
+++ b/internal/api/v3/buildpacks/post_test.go
@@ -35,6 +35,24 @@ func TestPostBuildpackTestSuite(t *testing.T) {
 	suite.Run(t, new(PostBuildpackTestSuite))
 }
 
+func (suite *PostBuildpackTestSuite) TestInsertBuildpackswithInvalidPosition() {
+	reader := strings.NewReader(`{"name" : "test_buildpack", "position": 0}`)
+	suite.req.Body = ioutil.NopCloser(reader)
+
+	var err *v3.CfAPIError
+	suite.ErrorAs(suite.controller.Post(suite.ctx), &err)
+	suite.Equal(http.StatusBadRequest, err.HTTPStatus)
+}
+
+func (suite *PostBuildpackTestSuite) TestInsertBuildpackswithInvalidName() {
+	reader := strings.NewReader(`{"name" : "", "position": 1}`)
+	suite.req.Body = ioutil.NopCloser(reader)
+
+	var err *v3.CfAPIError
+	suite.ErrorAs(suite.controller.Post(suite.ctx), &err)
+	suite.Equal(http.StatusBadRequest, err.HTTPStatus)
+}
+
 func (suite *PostBuildpackTestSuite) TestInsertBuildpackswithName() {
 	buildpackName := "test_buildpack" //nolint:goconst // mistakenly gets taken as duplicate
 	reader := strings.NewReader(fmt.Sprintf(`{"name" : "%s"}`, buildpackName))

--- a/internal/api/v3/buildpacks/post_test.go
+++ b/internal/api/v3/buildpacks/post_test.go
@@ -26,6 +26,9 @@ type PostBuildpackTestSuite struct {
 
 func (suite *PostBuildpackTestSuite) SetupTest() {
 	suite.SetupTestSuite(http.MethodPost, "http://localhost:8080/v3/buildpacks")
+	suite.mockDB.ExpectBegin()
+	suite.mockDB.ExpectCommit()
+	suite.mockDB.ExpectRollback()
 }
 
 func TestPostBuildpackTestSuite(t *testing.T) {
@@ -106,13 +109,37 @@ func (suite *PostBuildpackTestSuite) TestInsertBuildpackWithExistedPosition() {
 	suite.req.Body = ioutil.NopCloser(reader)
 
 	suite.querier.EXPECT().All(gomock.Any(), gomock.Any()).Return(models.BuildpackSlice{
-		{Name: "existing_buildpack", Position: 1},
+		{Name: "existing_buildpack_1", Position: 1},
+		{Name: "existing_buildpack_2", Position: 2},
 	}, nil)
 
-	var err *v3.CfAPIError
-	suite.ErrorAs(suite.controller.Post(suite.ctx), &err)
-	suite.Equal(http.StatusUnprocessableEntity, err.HTTPStatus)
-	suite.Contains(err.Detail, "Position already exists")
+	suite.updater.EXPECT().Update(
+		&models.Buildpack{Name: "existing_buildpack_1", Position: 2},
+		gomock.Any(), gomock.Any(), boil.Whitelist(models.BuildpackColumns.Position))
+	suite.updater.EXPECT().Update(
+		&models.Buildpack{Name: "existing_buildpack_2", Position: 3},
+		gomock.Any(), gomock.Any(), boil.Whitelist(models.BuildpackColumns.Position))
+
+	var got *models.Buildpack
+	suite.inserter.
+		EXPECT().
+		Insert(gomock.AssignableToTypeOf(&models.Buildpack{}), gomock.Any(), gomock.Any(), boil.Infer()).
+		DoAndReturn(func(o *models.Buildpack, _, _, _ interface{}) error {
+			got = o
+			return nil
+		})
+	suite.presenter.On("ResponseObject", mock.Anything, mock.Anything).Return(&Response{}, nil)
+
+	err := suite.controller.Post(suite.ctx)
+	suite.NoError(err)
+
+	suite.Equal(buildpackName, got.Name)
+	suite.Equal(1, got.Position)
+
+	if suite.NoError(err, fmt.Errorf("%w", errors.Unwrap(err)).Error()) {
+		suite.presenter.AssertCalled(suite.T(), "ResponseObject", got, mock.Anything)
+		suite.Equal(http.StatusOK, suite.ctx.Response().Status)
+	}
 }
 
 func (suite *PostBuildpackTestSuite) TestInsertBuildpackWithoutExistedPosition() {
@@ -137,6 +164,38 @@ func (suite *PostBuildpackTestSuite) TestInsertBuildpackWithoutExistedPosition()
 
 	suite.Equal(buildpackName, got.Name)
 	suite.Equal(position, got.Position)
+
+	if suite.NoError(err, fmt.Errorf("%w", errors.Unwrap(err)).Error()) {
+		suite.presenter.AssertCalled(suite.T(), "ResponseObject", got, mock.Anything)
+		suite.Equal(http.StatusOK, suite.ctx.Response().Status)
+	}
+}
+
+func (suite *PostBuildpackTestSuite) TestInsertBuildpackWithNextPosition() {
+	buildpackName, position := "test_buildpack", 1000
+	reader := strings.NewReader(fmt.Sprintf(`{"name" : "%s", "position" : %d}`, buildpackName, position))
+	suite.req.Body = ioutil.NopCloser(reader)
+
+	suite.querier.EXPECT().All(gomock.Any(), gomock.Any()).Return(models.BuildpackSlice{
+		{Name: "existing_buildpack_1", Position: 1},
+		{Name: "existing_buildpack_2", Position: 2},
+	}, nil)
+
+	var got *models.Buildpack
+	suite.inserter.
+		EXPECT().
+		Insert(gomock.AssignableToTypeOf(&models.Buildpack{}), gomock.Any(), gomock.Any(), boil.Infer()).
+		DoAndReturn(func(o *models.Buildpack, _, _, _ interface{}) error {
+			got = o
+			return nil
+		})
+	suite.presenter.On("ResponseObject", mock.Anything, mock.Anything).Return(&Response{}, nil)
+
+	err := suite.controller.Post(suite.ctx)
+	suite.NoError(err)
+
+	suite.Equal(buildpackName, got.Name)
+	suite.Equal(3, got.Position)
 
 	if suite.NoError(err, fmt.Errorf("%w", errors.Unwrap(err)).Error()) {
 		suite.presenter.AssertCalled(suite.T(), "ResponseObject", got, mock.Anything)


### PR DESCRIPTION
CCNG has a special behaivor when posting (also delete) new buildpacks.
It shuffles existing buildpacks so that there is no gap in positions.
`Position` is a field in the buildpacks table which is needed for the
buildpack auto-detection.
Example:
    Current state: there are 10 buildpacks with position 1-10
    New BP with postion 1 or no position provided -> all 10 previous positions will be shifted +1
    New BP with position 1899 -> new BP will be created with last
    position plus one (11 with current state)

This commit adds the same behavior for post requests in go-cf-api.
